### PR TITLE
Add database configuration module

### DIFF
--- a/global-search-poc/config/db_config.py
+++ b/global-search-poc/config/db_config.py
@@ -1,0 +1,11 @@
+# Database config for H2 connection
+
+# Path to your downloaded H2 JAR file
+H2_JAR_PATH = "/workspace/Global_Search_POC/h2_db/h2-2.x.x.jar"
+
+# JDBC URL for your H2 (Embedded Mode)
+JDBC_URL = "jdbc:h2:~/test;MODE=Oracle"
+
+# DB credentials (H2 default)
+DB_USER = "sa"
+DB_PASSWORD = ""

--- a/global-search-poc/database/schema.sql
+++ b/global-search-poc/database/schema.sql
@@ -1,0 +1,21 @@
+-- ORDERS table
+CREATE TABLE orders (
+    order_id VARCHAR(20) PRIMARY KEY,
+    customer_id VARCHAR(20),
+    order_date DATE,
+    amount NUMERIC(10, 2),
+    status VARCHAR(20)
+);
+
+-- CHANGE_LOG table (for delta refresh simulation)
+CREATE TABLE change_log (
+    id IDENTITY PRIMARY KEY,
+    table_name VARCHAR(50),
+    record_id VARCHAR(20),
+    change_type VARCHAR(10),
+    change_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+
+-- This file is your database initializer.
+-- You run this once in your H2 console to set up your mock DB.


### PR DESCRIPTION
## Summary
- add H2 database config file with path, JDBC URL, and default credentials

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b48550a5c8333a96c642241cdf73e