### PR TITLE
Add DB config package and connection helper

### DIFF
--- a/config/db_config.py
+++ b/config/db_config.py
@@ -1,0 +1,11 @@
+# Database config for H2 connection
+
+# Path to your downloaded H2 JAR file
+H2_JAR_PATH = "/workspace/Global_Search_POC/h2_db/h2-2.x.x.jar"
+
+# JDBC URL for your H2 (Embedded Mode)
+JDBC_URL = "jdbc:h2:~/test;MODE=Oracle"
+
+# DB credentials (H2 default)
+DB_USER = "sa"
+DB_PASSWORD = ""

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,21 @@
+-- ORDERS table
+CREATE TABLE orders (
+    order_id VARCHAR(20) PRIMARY KEY,
+    customer_id VARCHAR(20),
+    order_date DATE,
+    amount NUMERIC(10, 2),
+    status VARCHAR(20)
+);
+
+-- CHANGE_LOG table (for delta refresh simulation)
+CREATE TABLE change_log (
+    id IDENTITY PRIMARY KEY,
+    table_name VARCHAR(50),
+    record_id VARCHAR(20),
+    change_type VARCHAR(10),
+    change_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+
+-- This file is your database initializer.
+-- You run this once in your H2 console to set up your mock DB.

--- a/delta_refresh/delta_engine.py
+++ b/delta_refresh/delta_engine.py
@@ -1,0 +1,26 @@
+from layer1.db_connection import get_db_connection
+
+
+def process_delta_changes():
+    """Process all rows in change_log and then clear the log."""
+    conn = get_db_connection()
+    try:
+        curs = conn.cursor()
+        try:
+            curs.execute("SELECT record_id, change_type, change_timestamp FROM change_log")
+            rows = curs.fetchall()
+            for row in rows:
+                record_id, change_type, timestamp = row
+                print(record_id, change_type, timestamp)
+
+            # After processing, clear the change_log
+            curs.execute("DELETE FROM change_log")
+            conn.commit()
+        finally:
+            curs.close()
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    process_delta_changes()

--- a/layer1/db_connection.py
+++ b/layer1/db_connection.py
@@ -1,10 +1,12 @@
-"""Database connection utilities for H2."""
+import jaydebeapi
+from config import db_config
 
-from pathlib import Path
 
-H2_JAR = Path(__file__).resolve().parents[1] / 'h2_db' / 'h2-2.x.x.jar'
-SCHEMA_SQL = Path(__file__).resolve().parents[1] / 'h2_db' / 'schema.sql'
-
-def get_connection_string(database_path: str) -> str:
-    """Return a JDBC connection string for the H2 database."""
-    return f"jdbc:h2:{database_path}"
+def get_db_connection():
+    conn = jaydebeapi.connect(
+        "org.h2.Driver",
+        db_config.JDBC_URL,
+        [db_config.DB_USER, db_config.DB_PASSWORD],
+        db_config.H2_JAR_PATH
+    )
+    return conn

--- a/layer1/extractor.py
+++ b/layer1/extractor.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from layer1.db_connection import get_db_connection
+
+
+def extract_change_log():
+    """Query all entries from the change_log table and return a DataFrame."""
+    conn = get_db_connection()
+    try:
+        df = pd.read_sql("SELECT * FROM change_log", conn)
+        print(df)
+        return df
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    extract_change_log()

--- a/layer1/inserter.py
+++ b/layer1/inserter.py
@@ -1,0 +1,36 @@
+import datetime
+from layer1.db_connection import get_db_connection
+
+
+def insert_order(order_id, customer_id, order_date, amount, status):
+    conn = get_db_connection()
+    curs = conn.cursor()
+
+    try:
+        # Insert into orders table
+        curs.execute(
+            """
+            INSERT INTO orders (order_id, customer_id, order_date, amount, status)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (order_id, customer_id, order_date, amount, status),
+        )
+
+        # Log into change_log table
+        curs.execute(
+            """
+            INSERT INTO change_log (table_name, record_id, change_type)
+            VALUES ('orders', ?, 'INSERT')
+            """,
+            (order_id,),
+        )
+
+        conn.commit()
+    finally:
+        curs.close()
+        conn.close()
+
+
+# Example usage
+if __name__ == "__main__":
+    insert_order("O1001", "C100", datetime.date.today(), 5000.00, "PAID")

--- a/layer1/sanity_check.py
+++ b/layer1/sanity_check.py
@@ -1,0 +1,28 @@
+from layer1.db_connection import get_db_connection
+
+
+def run_sanity_check():
+    """Execute simple queries to verify orders and change_log tables."""
+    conn = get_db_connection()
+    try:
+        curs = conn.cursor()
+        try:
+            curs.execute("SELECT * FROM orders")
+            orders = curs.fetchall()
+            print("Orders:")
+            for row in orders:
+                print(row)
+
+            curs.execute("SELECT * FROM change_log")
+            changes = curs.fetchall()
+            print("Change Log:")
+            for row in changes:
+                print(row)
+        finally:
+            curs.close()
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    run_sanity_check()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-
+jaydebeapi
+pandas


### PR DESCRIPTION
## Summary
- move config and database folders to repository root
- implement `get_db_connection` using `jaydebeapi`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b48550a5c8333a96c642241cdf73e